### PR TITLE
Build and publish pre-built binaries and other CI improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Build
 
 on:
   push:
@@ -10,14 +10,108 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  linux:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: install_dependencies
-      run: sudo apt-get install --no-install-recommends libxcb-shape0-dev libxcb-xfixes0-dev
-    - name: build
-      run: cargo build --verbose
-    - name: check
-      run: cargo test --verbose
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.53.0
+        components: clippy, rustfmt
+        default: true
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends libxcb-shape0-dev libxcb-xfixes0-dev
+
+    - name: Build binary
+      run: |
+        cargo build --verbose --release
+    - name: Run tests
+      run: |
+        cargo test --verbose
+
+    - name: Upload binary
+      uses: actions/upload-artifact@v2
+      with:
+        name: leafish-linux
+        path: target/release/leafish
+    - name: Release binary
+      if: startsWith(github.ref, 'refs/tags/')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          leafish*
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.53.0
+          components: clippy, rustfmt
+          default: true
+
+      - name: Build binary
+        run: |
+          cargo build --verbose --release
+      - name: Run tests
+        run: |
+          cargo test --verbose
+
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: leafish.exe
+          path: target/release/leafish.exe
+      - name: Release binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/release/leafish.exe
+
+  macos:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.53.0
+          components: clippy, rustfmt
+          default: true
+
+      - name: Build binary
+        run: |
+          cargo build --verbose --release
+          chmod a+x target/release/leafish
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.14
+      - name: Run tests
+        run: |
+          cargo test --verbose
+
+      - name: Package binary
+        run: |
+          cargo install cargo-bundle
+          cargo bundle --release
+          chmod a+x target/release/bundle/osx/Leafish.app/Contents/MacOS/leafish
+          cd target/release/bundle/osx
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: Leafish.app
+          path: target/release/bundle/osx/Leafish.app
+      - name: Release binary
+        if: startsWith(github.ref, 'refs/tag/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            target/release/bundle/osx/Leafish.app

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,12 @@ description = "Multi-protocol multi-platform Minecraft-compatible client"
 repository = "https://github.com/terrarier2111/Leafish"
 license = "MIT/Apache-2.0"
 
-#[lib]
-#crate-type = ["cdylib", "rlib"]
-#path = "src/main.rs"
+[package.metadata.bundle]
+name = "Leafish"
+identifier = "io.github.terrarier2111.leafish"
+icon = ["resources/icon*.png"]
+category = "Game"
+osx_minimum_system_version = "10.14"
 
 [profile.dev]
 split-debuginfo = "unpacked"


### PR DESCRIPTION
Build binaries for Linux (Ubuntu), Windows and macOS.

Also run Clippy and rustfmt to make sure all code uses the same formatting.

This needs a Github token added to the project secrets. @terrarier2111 could you please look into that? https://docs.github.com/en/actions/reference/encrypted-secrets has information about it, the repository owner needs to add it.