### PR TITLE
Bumped up macOS version

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
             target/release/leafish.exe
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since GitHub hasn't updated macos-latest I bumped up the macOS version from 10.15 to 10.16
(For some reason, the macOS 10.15 CI uses the Xcode 11 SDK, while the macOS 10.16 CI uses the Xcode 12.X SDK, which lead to less compatibility with the Rosetta 2 interpreter)